### PR TITLE
Update docker_image_push.yml to use correct dockerhub tag

### DIFF
--- a/.github/workflows/docker_image_push.yml
+++ b/.github/workflows/docker_image_push.yml
@@ -24,4 +24,4 @@ jobs:
         context: .
         file: ./docker/weekly_build/Dockerfile
         push: true
-        tags: ${{ secrets.DOCKERHUB_USERNAME }}/smardda-dagmc/v1
+        tags: ${{ secrets.DOCKERHUB_USERNAME }}/smardda-dagmc:v2


### PR DESCRIPTION
Set push to dockerhub under a new a tag in an attempt to stop weekly build/push to dockerhub