### PR TITLE
Feature  particle tracking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ message(STATUS "Found DAGMC config in: ${DAGMC_DIR}")
 message(STATUS "DAGMC_INCLUDE_DIRS is set to: ${DAGMC_INCLUDE_DIRS}")
 message(STATUS "DAGMC_LIBRARIES is set to: ${DAGMC_LIBRARIES}")
 
+find_library(libopenmc.so ~/openmc/openmc/openmc/lib/)
+
 
 enable_testing()
 

--- a/settings.txt
+++ b/settings.txt
@@ -1,5 +1,6 @@
 geo_input h5m/hashtag_mesh.h5m
 ray_qry exps/exps00010000.qry
 runcase eqdsk
-eqdsk_file eqdsk/F11.eqdsk 
+eqdsk_file eqdsk/g900003_00230_ITER_15MA_eqdsk16HR.txt 
 source_power 100.0
+cenopt 2

--- a/settings.txt
+++ b/settings.txt
@@ -1,6 +1,6 @@
 geo_input h5m/hashtag_mesh.h5m
 ray_qry exps/exps00010000.qry
 runcase eqdsk
-eqdsk_file eqdsk/g900003_00230_ITER_15MA_eqdsk16HR.txt 
+eqdsk_file eqdsk/F11.eqdsk 
 source_power 100.0
 cenopt 2

--- a/settings.txt
+++ b/settings.txt
@@ -1,6 +1,6 @@
-geo_input h5m/tokamak_vol.h5m
+geo_input box.h5m
 ray_qry exps/exps00010000.qry
 runcase eqdsk
-eqdsk_file eqdsk/F11.eqdsk 
+eqdsk_file eqdsk/EQ3.eqdsk 
 source_power 100.0
 cenopt 2

--- a/settings.txt
+++ b/settings.txt
@@ -1,4 +1,4 @@
-geo_input hcll.h5m
+geo_input hcll_up.h5m
 ray_qry exps/exps00010000.qry
 runcase eqdsk
 eqdsk_file eqdsk/EQ3.eqdsk 

--- a/settings.txt
+++ b/settings.txt
@@ -1,4 +1,4 @@
-geo_input h5m/hashtag_mesh.h5m
+geo_input h5m/tokamak_vol.h5m
 ray_qry exps/exps00010000.qry
 runcase eqdsk
 eqdsk_file eqdsk/F11.eqdsk 

--- a/settings.txt
+++ b/settings.txt
@@ -1,4 +1,4 @@
-geo_input box.h5m
+geo_input hcll.h5m
 ray_qry exps/exps00010000.qry
 runcase eqdsk
 eqdsk_file eqdsk/EQ3.eqdsk 

--- a/src/aegis/CMakeLists.txt
+++ b/src/aegis/CMakeLists.txt
@@ -14,4 +14,4 @@ target_link_libraries(${PROJECT_NAME} PRIVATE ${PROJECT_NAME}-lib)
 target_link_libraries(${PROJECT_NAME} PUBLIC ${Boost_LIBRARIES})
 target_link_libraries(${PROJECT_NAME} PUBLIC dagmc-shared uwuw-shared )
 target_link_libraries(${PROJECT_NAME} PUBLIC OpenMP::OpenMP_CXX)
-
+target_link_libraries(${PROJECT_NAME} PUBLIC ~/openmc/openmc/openmc/lib/libopenmc.so)

--- a/src/aegis/aegis.cpp
+++ b/src/aegis/aegis.cpp
@@ -29,8 +29,11 @@
 #include "integrator.h"
 #include "coordtfm.h"
 #include "alglib/interpolation.h"
+#include "openmc/particle.h"
+
 
 using namespace moab;
+using namespace openmc;
 using namespace coordTfm;
 
 using moab::DagMC;
@@ -56,6 +59,9 @@ int main() {
   settings settings;
   settings.load_settings();
   LOG_WARNING << "h5m Faceted Geometry file to be used = " << settings.geo_input;
+  openmc::SourceSite src; 
+  std::cout << "neutron.wgt = " << src.wgt << std::endl;
+
 
 
   static const char* input_file = settings.geo_input.c_str();
@@ -352,6 +358,7 @@ int main() {
     EquData.init_interp_splines();
     EquData.gnuplot_out();
     EquData.centre(settings.cenopt);
+    EquData.rz_splines();
 
     bool plotRZ = true;
     bool plotXYZ = true;

--- a/src/aegis/aegis.cpp
+++ b/src/aegis/aegis.cpp
@@ -351,7 +351,7 @@ int main() {
 
     EquData.init_interp_splines();
     EquData.gnuplot_out();
-    EquData.centre();
+    EquData.centre(settings.cenopt);
 
     bool plotRZ = true;
     bool plotXYZ = true;

--- a/src/aegis_lib/coordtfm.cpp
+++ b/src/aegis_lib/coordtfm.cpp
@@ -13,7 +13,7 @@ std::vector<double> coordTfm::cart_to_polar(std::vector<double> inputVector,
 {
   std::vector<double> outputVector(3);
   double r; // polar r 
-  double zeta; // polar zeta
+  double phi; // polar phi
   double x; // cart x 
   double y; // cart y
   double z; // cart z
@@ -22,11 +22,11 @@ std::vector<double> coordTfm::cart_to_polar(std::vector<double> inputVector,
   {
     r = inputVector[0]; 
     z = inputVector[1]; 
-    zeta = inputVector[2];
+    phi = inputVector[2];
 
-    x = r*cos(zeta); // calculate x
+    x = r*cos(phi); // calculate x
 
-    y = -r*sin(zeta); // calculate y
+    y = -r*sin(phi); // calculate y
 
     outputVector[0] = x;
     outputVector[1] = y;
@@ -39,11 +39,11 @@ std::vector<double> coordTfm::cart_to_polar(std::vector<double> inputVector,
     z = inputVector[2];
 
     r = sqrt(pow(x,2) + pow(y,2)); // calculate 
-    zeta = atan2(-y,x); // calculate zeta 
+    phi = atan2(-y,x); // calculate phi 
 
     outputVector[0] = r;
     outputVector[1] = z; 
-    outputVector[2] = zeta;
+    outputVector[2] = phi;
   } 
   return outputVector;
 }
@@ -54,7 +54,7 @@ std::vector<double> coordTfm::polar_to_flux(std::vector<double> inputVector,
   std::vector<double> outputVector(3);
   double r; // local polar r
   double z; // local polar z
-  double zeta; // local polar zeta
+  double phi; // local polar phi
   double psi; // local psi  
   double theta; // local theta 
 
@@ -62,7 +62,7 @@ std::vector<double> coordTfm::polar_to_flux(std::vector<double> inputVector,
   {
     psi = inputVector[0];
     theta = inputVector[1];
-    zeta = inputVector[2];
+    phi = inputVector[2];
     
     
   }
@@ -70,7 +70,7 @@ std::vector<double> coordTfm::polar_to_flux(std::vector<double> inputVector,
   {
     r = inputVector[0];
     z = inputVector[1];
-    zeta = inputVector[2];
+    phi = inputVector[2];
 
     psi = alglib::spline2dcalc(EquData.psiSpline, r, z); // spline interpolation of psi(R,Z)
     theta = atan2(z-EquData.zcen, r-EquData.rcen);
@@ -82,7 +82,7 @@ std::vector<double> coordTfm::polar_to_flux(std::vector<double> inputVector,
 
   outputVector[0] = psi;
   outputVector[1] = theta;
-  outputVector[2] = zeta;
+  outputVector[2] = phi;
 
   return outputVector;
 }

--- a/src/aegis_lib/coordtfm.cpp
+++ b/src/aegis_lib/coordtfm.cpp
@@ -4,24 +4,25 @@
 #include <string>
 
 #include "coordtfm.h"
-#include "equData.h" 
+#include "equData.h"
 #include "alglib/interpolation.h"
+#include "simpleLogger.h"
 
 
 std::vector<double> coordTfm::cart_to_polar(std::vector<double> inputVector,
                                                    std::string direction)
 {
   std::vector<double> outputVector(3);
-  double r; // polar r 
+  double r; // polar r
   double phi; // polar phi
-  double x; // cart x 
+  double x; // cart x
   double y; // cart y
   double z; // cart z
 
   if (direction == "backwards")
   {
-    r = inputVector[0]; 
-    z = inputVector[1]; 
+    r = inputVector[0];
+    z = inputVector[1];
     phi = inputVector[2];
 
     x = r*cos(phi); // calculate x
@@ -32,39 +33,39 @@ std::vector<double> coordTfm::cart_to_polar(std::vector<double> inputVector,
     outputVector[1] = y;
     outputVector[2] = z;
   }
-  else 
+  else
   {
-    x = inputVector[0]; 
+    x = inputVector[0];
     y = inputVector[1];
     z = inputVector[2];
 
-    r = sqrt(pow(x,2) + pow(y,2)); // calculate 
-    phi = atan2(-y,x); // calculate phi 
+    r = sqrt(pow(x,2) + pow(y,2)); // calculate
+    phi = atan2(-y,x); // calculate phi
 
     outputVector[0] = r;
-    outputVector[1] = z; 
+    outputVector[1] = z;
     outputVector[2] = phi;
-  } 
+  }
   return outputVector;
 }
 
-std::vector<double> coordTfm::polar_to_flux(std::vector<double> inputVector, 
+std::vector<double> coordTfm::polar_to_flux(std::vector<double> inputVector,
                                             std::string direction, equData& EquData)
 {
   std::vector<double> outputVector(3);
   double r; // local polar r
   double z; // local polar z
   double phi; // local polar phi
-  double psi; // local psi  
-  double theta; // local theta 
+  double psi; // local psi
+  double theta; // local theta
 
   if (direction == "backwards") // backwards transform (flux -> polar coords) TODO
   {
     psi = inputVector[0];
     theta = inputVector[1];
     phi = inputVector[2];
-    
-    
+
+
   }
   else // fowards transform (polar -> flux coords)
   {
@@ -74,7 +75,7 @@ std::vector<double> coordTfm::polar_to_flux(std::vector<double> inputVector,
 
     psi = alglib::spline2dcalc(EquData.psiSpline, r, z); // spline interpolation of psi(R,Z)
     theta = atan2(z-EquData.zcen, r-EquData.rcen);
-    if (theta < -M_PI_2) 
+    if (theta < -M_PI_2)
     {
       theta = 2*M_PI+theta;
     }
@@ -86,3 +87,49 @@ std::vector<double> coordTfm::polar_to_flux(std::vector<double> inputVector,
 
   return outputVector;
 }
+
+// coordSystem =
+// 1 - Cartesian
+// 2 - Polar-Toroidal
+// 3 - Flux Coordinates
+vecTfm::vecTfm(std::vector<double> vector, int coordSystem, equData &EquData)
+{
+  switch (coordSystem)
+  {
+    case 1:
+      cartCoord = vector;
+      polarCoord = coordTfm::cart_to_polar(cartCoord, "forwards");
+      fluxCoord = coordTfm::polar_to_flux(polarCoord, "forwards", EquData);
+    case 2:
+      polarCoord = vector;
+      fluxCoord = coordTfm::polar_to_flux(polarCoord, "forwards", EquData);
+      cartCoord = coordTfm::cart_to_polar(cartCoord, "backwards");
+    // case 3:
+    //   flux = vector;
+    //   // TODO backwards tfm from flux
+    default:
+      LOG_INFO << "No coordinate system provided for vecTfm constructor. Assume Cartesian";
+      cartCoord = vector;
+  }
+}
+
+
+// return cartesian vector
+std::vector<double> vecTfm::cart()
+{
+  return cartCoord;
+}
+
+std::vector<double> vecTfm::polar()
+{
+  // not sure why this is broken atm
+  // cart and flux returns work but this is broken for some reason
+  std::cout << polarCoord[0] << polarCoord[1] << polarCoord[2] << std::endl;
+  return polarCoord;
+}
+
+std::vector<double> vecTfm::flux()
+{
+  return fluxCoord;
+}
+

--- a/src/aegis_lib/coordtfm.h
+++ b/src/aegis_lib/coordtfm.h
@@ -10,6 +10,7 @@
 namespace coordTfm
 {
 
+
 // Cartesian to polar toroidal (direction = "backwards" for polar->cartesian)
 std::vector<double> cart_to_polar(std::vector<double> inputVector,
                                   std::string direction);
@@ -18,6 +19,21 @@ std::vector<double> cart_to_polar(std::vector<double> inputVector,
 std::vector<double> polar_to_flux(std::vector<double> inputVector, std::string direction,
                                   equData& EquData);
 
-}
+};
+
+
+  class vecTfm
+  {
+    private:
+    std::vector<double> cartCoord;
+    std::vector<double> polarCoord;
+    std::vector<double> fluxCoord;
+
+    public: 
+    vecTfm(std::vector<double> vector, int coordSystem, equData &EquData);
+    std::vector<double> cart();
+    std::vector<double> polar();
+    std::vector<double> flux();
+  };
 
 #endif

--- a/src/aegis_lib/equData.cpp
+++ b/src/aegis_lib/equData.cpp
@@ -671,7 +671,10 @@ void equData::rz_splines()
   double zpsi; // psi
   double zpsi_i; // psi_i
   
+  double ntmax = 33;
+  double ntmin = 1;
 
+  intheta = ntmax - ntmin+1;
 
   // loop over angle
 
@@ -682,7 +685,7 @@ void equData::rz_splines()
     ztheta = thetamin + j*dtheta;
     zcostheta = cos(ztheta);
     zsintheta = sin(ztheta);
-    //std::cout << "THETAMIN = " << thetamin << std::endl;
+    std::cout << "THETAMIN = " << thetamin << std::endl;
 
 
   }
@@ -717,16 +720,25 @@ std::vector<double> equData::b_field(std::vector<double> position,
     zz = polarPosition[1];
   }
 
-  // evaluate psi and psi derivs at given (R,Z) coords
-  alglib::spline2ddiff(psiSpline, zr, zz, zpsi, zdpdr, zdpdz, null); 
+  if (zr < rmin || zr > rmax || zz < zmin || zz > zmax )
+  {
+    bVector[0] = 0;
+    bVector[1] = 0;
+    bVector[2] = 0;
+  }
+  else
+  {
+    // evaluate psi and psi derivs at given (R,Z) coords
+    alglib::spline2ddiff(psiSpline, zr, zz, zpsi, zdpdr, zdpdz, null); 
 
-  // evaluate I aka f at psi (I aka f is the flux function) 
-  zf = alglib::spline1dcalc(fSpline, zpsi);
+    // evaluate I aka f at psi (I aka f is the flux function) 
+    zf = alglib::spline1dcalc(fSpline, zpsi);
 
-  // calculate B in cylindrical toroidal polars
-  bVector[0] = -zdpdz/zr; // B_R
-  bVector[1] = zdpdr/zr; // B_Z
-  bVector[2] = zf/zr; // B_T - toroidal component of field directed along phi
+    // calculate B in cylindrical toroidal polars
+    bVector[0] = -zdpdz/zr; // B_R
+    bVector[1] = zdpdr/zr; // B_Z
+    bVector[2] = zf/zr; // B_T - toroidal component of field directed along phi
+  }
 
   // return the calculated B vector 
   return bVector;

--- a/src/aegis_lib/equData.cpp
+++ b/src/aegis_lib/equData.cpp
@@ -672,6 +672,7 @@ void equData::rz_splines()
   double zpsi_i; // psi_i
   
 
+
   // loop over angle
 
   int counter = 0;
@@ -681,6 +682,7 @@ void equData::rz_splines()
     ztheta = thetamin + j*dtheta;
     zcostheta = cos(ztheta);
     zsintheta = sin(ztheta);
+    //std::cout << "THETAMIN = " << thetamin << std::endl;
 
 
   }
@@ -754,7 +756,7 @@ std::vector<double> equData::b_field_cart(std::vector<double> polarBVector, doub
 
   return cartBVector;
 
-  
+
 }
 
 void equData::write_bfield(bool plotRZ, bool plotXYZ)

--- a/src/aegis_lib/equData.cpp
+++ b/src/aegis_lib/equData.cpp
@@ -746,7 +746,7 @@ std::vector<double> equData::b_field(std::vector<double> position,
   
 }
 
-std::vector<double> equData::b_field_cart(std::vector<double> polarBVector, double phi)
+std::vector<double> equData::b_field_cart(std::vector<double> polarBVector, double phi, int normalise)
 {
   std::vector<double> cartBVector(3);
   double zbx; // cartesian Bx component
@@ -766,10 +766,19 @@ std::vector<double> equData::b_field_cart(std::vector<double> polarBVector, doub
   cartBVector[1] = zby;
   cartBVector[2] = zbz; 
 
+  if (normalise == 1)
+  {
+    double norm;
+    norm = sqrt(pow(cartBVector[0],2) + pow(cartBVector[1],2) + pow(cartBVector[2],2));
+    cartBVector[0] = cartBVector[0]/norm;
+    cartBVector[1] = cartBVector[1]/norm; 
+    cartBVector[2] = cartBVector[2]/norm;
+  }
+
   return cartBVector;
-
-
 }
+
+
 
 void equData::write_bfield(bool plotRZ, bool plotXYZ)
 {
@@ -828,7 +837,7 @@ void equData::write_bfield(bool plotRZ, bool plotXYZ)
             LOG_ERROR << "Negative R Values when attempting plot magnetic field. Fixup eqdsk required";
           }
           polarB = b_field(polarPos, "polar"); // calculate B(R,Z,phi)
-          cartB = b_field_cart(polarB, polarPos[2]); // transform to B(x,y,z)
+          cartB = b_field_cart(polarB, polarPos[2], 0); // transform to B(x,y,z)
           cartPos = coordTfm::cart_to_polar(polarPos, "backwards"); // transform position to cartesian
 
           // write out magnetic field data for plotting

--- a/src/aegis_lib/equData.cpp
+++ b/src/aegis_lib/equData.cpp
@@ -23,7 +23,8 @@ eqdskData equData::get_eqdsk_struct()
 
 // Read eqdsk file
 void equData::read_eqdsk(std::string filename)
-{
+{ 
+    LOG_TRACE << "-----equData.read_eqdsk()-----";
     eqdsk_file.open(filename);
     std::stringstream header_ss;
     std::string temp;
@@ -168,11 +169,15 @@ void equData::read_eqdsk(std::string filename)
     // scale for psibig (TODO)
     // if psibig 
     // scale by 2pi
+
+    
 }
 
 // Read 1D array from eqdsk (PRIVATE)
 std::vector<double> equData::read_array(int n, std::string varName)
 {
+  LOG_TRACE << "-----equData.read_array()-----";
+
   std::vector<double> work1d(n); // working vector of doubles of size n
   LOG_WARNING << "Reading " << varName << " values...";
   for(int i=0; i<nw; i++) // Read in n elements into vector from file
@@ -181,11 +186,15 @@ std::vector<double> equData::read_array(int n, std::string varName)
   }
   LOG_WARNING << "Number of " << varName << " values read = " << n;
   return work1d;
+
+ 
 }
 
 // Read 2D array from eqdsk (PRIVATE)
 std::vector<std::vector<double>> equData::read_2darray(int nx, int ny, std::string varName)
 {
+  LOG_TRACE << "-----equData.read_2darray()-----";
+
   std::vector<std::vector<double>> work2d(nw, std::vector<double>(nh));
   LOG_WARNING << "Reading " << varName << " values...";
   for (int i=0; i<nx; i++)
@@ -198,11 +207,14 @@ std::vector<std::vector<double>> equData::read_2darray(int nx, int ny, std::stri
   }
   LOG_WARNING << "Number of " << varName << " values read = " << nx*ny;
   return work2d;
+
+  
 }
 
 // Write out eqdsk data back out in eqdsk format
 void equData::write_eqdsk_out()
 {
+  LOG_TRACE << "-----equData.write_eqdsk_out()-----";
   std::ofstream eqdsk_out("eqdsk.out");
   eqdsk_out << std::setprecision(9) << std::scientific;
   eqdsk_out << std::setiosflags(std::ios::uppercase);
@@ -275,11 +287,14 @@ void equData::write_eqdsk_out()
     counter = 0;
     eqdsk_out << std::endl;
   }
+
+  
 }
 
 // Write singular line out in EQDSK format (PRIVATE) 
 int equData::eqdsk_line_out(std::ofstream &file, double element, int counter)
     {
+      LOG_TRACE << "-----equData.eqdsk_line_out()-----";
       if (counter == 5)
       {
         file << std::endl;
@@ -294,24 +309,29 @@ int equData::eqdsk_line_out(std::ofstream &file, double element, int counter)
         file << element;
       }
       counter +=1;
+
+     
+
       return counter;
     }
 
 // Write out eqdsk arrays (PRIVATE)
 void equData::eqdsk_write_array(std::ofstream &file, std::vector<double> array, int counter)
 {
+  LOG_TRACE << "-----equData.eqdsk_write_array()-----";
   double element;
   for(int i=0; i<nw; i++)
   {
     element = array[i];
     counter = eqdsk_line_out(file, element, counter);
   }
+  
 }
 
 // Initialise the 1D arrays and 2d spline functions
 void equData::init_interp_splines()
 {
-
+  LOG_TRACE << "-----equData.init_interp_splines()-----";
   double r_pts[nw];
   double z_pts[nh];
   r_pts[0] = rmin;
@@ -377,12 +397,13 @@ void equData::init_interp_splines()
 
   // create 1d spline for f(psi) aka eqdsk.fpol
   //alglib::spline1dbuildlinear(f_grid,)
-
+  
 } 
 
 // Write out psi(R,Z) data for gnuplotting
 void equData::gnuplot_out()
 {
+  LOG_TRACE << "-----equData.gnuplot_out()-----";
   std::ofstream psiRZ_out;
   psiRZ_out.open("psi_RZ.gnu"); 
 
@@ -395,13 +416,14 @@ void equData::gnuplot_out()
     }
     psiRZ_out << std::endl;
   }
-
+  
 }
 
 // Set sign to determine if psi decreasing or increasing away from centre
 // (+1 -> Increase outwards, -1 -> Decrease outwards)
 void equData::set_rsig() 
 {
+  LOG_TRACE << "-----equData.set_rsig()-----";
   if (psiqbdry-psiaxis < 0)
   {
     rsig = -1.0;
@@ -411,12 +433,14 @@ void equData::set_rsig()
     rsig = 1.0;
   }
 
-  LOG_INFO << "Value of rsig (psiqbdry-psiaxis) = " << rsig;
+  LOG_WARNING << "Value of rsig (psiqbdry-psiaxis) = " << rsig;
+  
 }
 
 // Find central psi extrema
 void equData::centre()
 {
+  LOG_TRACE << "-----equData.centre-----";
   int igr; // R position index of global extremum
   int igz; // Z position index of global extremum
   int soutr = 10; // maximum number of outer searches
@@ -520,11 +544,12 @@ void equData::centre()
 
   LOG_WARNING << "Rcen value calculated from equData.centre() = " << rcen;
   LOG_WARNING << "Zcen value calculated from equData.centre() = " << zcen;
-
+  
 }
 
 void equData::r_extrema()
 {
+  LOG_TRACE << "-----equData.r_extrema()-----";
   int nrsrsamp; // number of samples in r
   double zpsi; // psi
   double zdpdr; // dpsi/dr
@@ -599,12 +624,14 @@ void equData::r_extrema()
     //if (zpsi<psimin)
   }
 
+  
 }
 
 
 // Create 2d spline structures for R(psi,theta) and Z(psi,theta)
 void equData::rz_splines()
 {
+  LOG_TRACE << "-----equData.rz_splines()-----";
   int iext; // maximum allowed number of knots for spline in r
   int iknot; // actual number of knots for splinie in r
   int intheta; // actual number of angles defining R,Z(psi,theta)
@@ -641,7 +668,7 @@ void equData::rz_splines()
 
 
   }
-
+  
 }
 
 // Caculate B field vector (in toroidal polars) at given position
@@ -685,6 +712,8 @@ std::vector<double> equData::b_field(std::vector<double> position,
 
   // return the calculated B vector 
   return bVector;
+
+  
 }
 
 std::vector<double> equData::b_field_cart(std::vector<double> polarBVector, double phi)
@@ -708,10 +737,13 @@ std::vector<double> equData::b_field_cart(std::vector<double> polarBVector, doub
   cartBVector[2] = zbz; 
 
   return cartBVector;
+
+  
 }
 
 void equData::write_bfield(bool plotRZ, bool plotXYZ)
 {
+  LOG_TRACE << "-----equData.b_field_write()-----";
   std::vector<double> polarPos(3); // cartesian position P(x,y,z)
   std::vector<double> polarB(3); // polar toroidal magnetic field B(Br, Bz, Bphi)
   
@@ -787,11 +819,13 @@ void equData::write_bfield(bool plotRZ, bool plotXYZ)
     //  BField_out_xyz << std::endl;
     }
   }
+  
 }
 
 // get toroidal ripple term in magnetic field from external file or otherwise. By default use MAST term
 std::vector<double> equData::b_ripple(std::vector<double> pos, std::vector<double> bField)
 {
+  LOG_TRACE << "-----equData.b_ripple()-----";
   std::vector<double> bRipple(3); // toroidal ripple term
   double zr; // local R
   double zz; // local Z
@@ -805,5 +839,5 @@ std::vector<double> equData::b_ripple(std::vector<double> pos, std::vector<doubl
 
   
 
-
+  
 }

--- a/src/aegis_lib/equData.h
+++ b/src/aegis_lib/equData.h
@@ -45,8 +45,6 @@ struct eqdskData
 };
 
 
-
-
 class equData{
 
   eqdskData eqdsk;  
@@ -155,11 +153,10 @@ class equData{
 
   // Caculate B field vector (in toroidal polars) at given position
   // set string to "polar" if position vector already in polars
-  std::vector<double> b_field(std::vector<double> position, 
-                              std::string startingFrom);
+  std::vector<double> b_field(std::vector<double> position, std::string startingFrom);
   
   // Convert B Field vectors to cartesian given polar form and value of angle 
-  std::vector<double> b_field_cart(std::vector<double> polarBVector, double phi);
+  std::vector<double> b_field_cart(std::vector<double> polarBVector, double phi, int normalise); 
 
   // Write out positions and associated BField vectors in cartesian and/or polar toroidal
   void write_bfield(bool plotRZ, bool plotXYZ);

--- a/src/aegis_lib/equData.h
+++ b/src/aegis_lib/equData.h
@@ -78,8 +78,10 @@ class equData{
 
   public:
 
- 
-  
+  // Aegis run parameters
+  int cenopt; // option to determine how (Rcen,Zcen) is calculated 
+              // 1 - Use values from eqdsk 
+              // 2 - Calculate new values from starting search in centre of grid (currently broken) 
 
   int nw; // Number of horizontal R points in grid
   int nh; // Number of vertical Z points in grid
@@ -143,7 +145,7 @@ class equData{
   void gnuplot_out();
 
   // Find central psi extrema
-  void centre();
+  void centre(int cenopt);
 
   // calculate r_min and r_max as functions of theta_j
   void r_extrema();

--- a/src/aegis_lib/integrator.cpp
+++ b/src/aegis_lib/integrator.cpp
@@ -11,6 +11,8 @@
 // initialise list of EntityHandles and maps associated with 
 surfaceIntegrator::surfaceIntegrator(moab::Range const &Facets)
 {
+  LOG_TRACE << "-----surfaceIntegrator CONSTRUCTOR()-----";
+
   nFacets = Facets.size();
   for (auto i:Facets)
   {

--- a/src/aegis_lib/integrator.cpp
+++ b/src/aegis_lib/integrator.cpp
@@ -3,7 +3,7 @@
 #include <moab/Core.hpp>
 #include "moab/Interface.hpp"
 #include <moab/OrientedBoxTreeTool.hpp>
-
+#include "simpleLogger.h"
 
 
 

--- a/src/aegis_lib/integrator.cpp
+++ b/src/aegis_lib/integrator.cpp
@@ -14,6 +14,7 @@ surfaceIntegrator::surfaceIntegrator(moab::Range const &Facets)
   LOG_TRACE << "-----surfaceIntegrator CONSTRUCTOR()-----";
 
   nFacets = Facets.size();
+
   for (auto i:Facets)
   {
     facetEntities.push_back(i);
@@ -43,14 +44,28 @@ void surfaceIntegrator::ray_reflect_dir(double const prev_dir[3], double const s
   }
 }
 
-int_sorted_map surfaceIntegrator::sort_map(std::unordered_map<moab::EntityHandle, int> const &map)
+// return sorted map of EntityHandles against ints 
+void surfaceIntegrator::facet_values(std::unordered_map<moab::EntityHandle, int> const &map)
 {
-  int_sorted_map sorted_map(map.begin(), map.end());
-  return sorted_map;
+    int_sorted_map sortedMap(map.begin(), map.end());
+    for (auto const &pair: sortedMap)
+    {
+      if (pair.second > 0)
+      {
+        std::cout << "EntityHandle: " << pair.first << "[" << pair.second << "] rays hit" << std::endl;
+      }
+    }
 }
 
-dbl_sorted_map surfaceIntegrator::sort_map(std::unordered_map<moab::EntityHandle, double> const &map)
+// return sorted map of EntityHandles against doubles 
+void surfaceIntegrator::facet_values(std::unordered_map<moab::EntityHandle, double> const &map)
 {
-  dbl_sorted_map sorted_map(map.begin(), map.end());
-  return sorted_map;
+    dbl_sorted_map sortedMap(map.begin(), map.end());
+    for (auto const &pair: sortedMap)
+    {
+      if (pair.second > 0)
+      {
+        std::cout << "EntityHandle: " << pair.first << "[" << pair.second << "] rays hit" << std::endl;
+      }
+    }
 }

--- a/src/aegis_lib/integrator.h
+++ b/src/aegis_lib/integrator.h
@@ -13,6 +13,7 @@
 #include <variant>
 
 
+
 using namespace moab;
 
 
@@ -33,11 +34,13 @@ struct comp
 typedef std::set<std::pair<EntityHandle, int>, comp> int_sorted_map;
 typedef std::set<std::pair<EntityHandle, double>, comp> dbl_sorted_map;
 
+
 // integrator .h file
 
 class surfaceIntegrator 
 {
   public:
+
   int raysTotal=0; // Total number of rays fired into geometry
   int raysHit=0; // Number of rays hit
   int nFacets=0; // Number of facets in geometry
@@ -52,8 +55,14 @@ class surfaceIntegrator
 
   void ray_reflect_dir(double const prev_dir[3], double const surface_normal[3], // get reflected dir
                          double reflected_dir[3]); 
-  int_sorted_map sort_map(std::unordered_map<EntityHandle, int> const &map); // return sorted map of ints (as set<pair>)
-  dbl_sorted_map sort_map(std::unordered_map<EntityHandle, double> const &map); // return sorted map of doubles (as set<pair)
+  
+  // return sorted map of entityhandles against chosen value
+  void facet_values(std::unordered_map<EntityHandle, int> const &facetValueMap);
+  void facet_values(std::unordered_map<EntityHandle, double> const &map);
+
+/// TODO - Create a class that holds the unordered map and a string for the name of the map
+///      - Potentially also any other variables that may be useful (i.e units for power values) 
+
 };
 
 #endif

--- a/src/aegis_lib/integrator.h
+++ b/src/aegis_lib/integrator.h
@@ -5,12 +5,13 @@
 #include <cctype>
 #include <vector>
 #include <map>
+#include <set>
+#include <variant>
 #include <unordered_map>
 #include <moab/Core.hpp>
 #include "moab/Interface.hpp"
 #include <moab/OrientedBoxTreeTool.hpp>
-#include <set>
-#include <variant>
+#include "equData.h"
 
 
 
@@ -52,6 +53,7 @@ class surfaceIntegrator
   // Methods
   surfaceIntegrator(moab::Range const &Facets); // constructor
   void count_hit(EntityHandle facet_hit); // count hits belonging to each facet
+  void store_heat_flux(EntityHandle facet, double psi, equData EquData); // store the power associated with a particular facet
 
   void ray_reflect_dir(double const prev_dir[3], double const surface_normal[3], // get reflected dir
                          double reflected_dir[3]); 

--- a/src/aegis_lib/settings.cpp
+++ b/src/aegis_lib/settings.cpp
@@ -19,42 +19,46 @@
         return;
       }
 
+      int valueInt;
+
       std::string param;
-      std::string value;
+      std::string valueStr;
 
       while (!in.eof())
       {
         in >> param;
-        in >> value;
+        in >> valueStr;
 
         if (param == "geo_input")
         {
-          geo_input = value; // string
+          geo_input = valueStr; // string
         }
         else if (param == "ray_qry")
         {
-          ray_qry = value; // string
+          ray_qry = valueStr; // string
         }
         else if (param == "eqdsk_file")
         {
-          eqdsk_file = value; // string
+          eqdsk_file = valueStr; // string
         }
         else if (param == "runcase")
         {
-          runcase = value; // string
+          runcase = valueStr; // string
         }
 	      else if (param == "source_power")
 	      {
-	      source_power = value; // double
+	      source_power = valueStr; // double
 	      }
 	      else if (param == "reflections")
 	      {
-	      reflections = value; // int
+	      reflections = valueStr; // int
 	      }
         else if (param == "number_of_rays_fired")
 	      {
-	      nSample = value; // int
+	      nSample = valueStr; // int
 	      }
+        else if (param == "cenopt")
+        cenopt = std::stoi(valueStr);
       }
       in.close();
     }

--- a/src/aegis_lib/settings.hpp
+++ b/src/aegis_lib/settings.hpp
@@ -12,6 +12,7 @@ class settings{
     std::string source_power;
     std::string reflections;
     std::string nSample;
+    int cenopt;
     void load_settings();
 };
 

--- a/src/aegis_lib/source.cpp
+++ b/src/aegis_lib/source.cpp
@@ -5,6 +5,8 @@
 #include <math.h>
 #include "source.h"
 
+
+
 //create_source()
 
 // OpenMC has function IndependantSource() that generates an independant source
@@ -163,4 +165,10 @@ std::vector<double> triSource::get_random_pt()
     randomPt[i] = xyzA[i] + randomA*(xyzB[i] - xyzA[i]) + randomB*(xyzC[i] - xyzA[i]);
   }
   return randomPt;
+}
+
+void triSource::dagmcInstance(moab::DagMC* DAG)
+{
+  DAGInstance = DAG;
+  DAGInstance->write_mesh("dag.out", 1);
 }

--- a/src/aegis_lib/source.cpp
+++ b/src/aegis_lib/source.cpp
@@ -87,6 +87,8 @@ boxSource::boxSource(double xyz1[3], double xyz2[3])
   }  
 }
 
+
+
 void boxSource::get_pt()
 {
   std::random_device dev;
@@ -112,4 +114,53 @@ void boxSource::get_dir()
   dir[2] = cos(phi);
 }
 
+/////////
 
+// define plane via cartesian plane equation ax + by + cz + d = 0
+triSource::triSource(std::vector<double> xyz1, std::vector<double> xyz2, std::vector<double> xyz3)
+{
+  xyzA = xyz1;
+  xyzB = xyz2;
+  xyzC = xyz3;
+
+  std::vector<double> line1(3), line2(3);
+  for (int i=0; i<3; i++)
+  {
+    line1[i] = xyzB[i] - xyzA[i];
+    line2[i] = xyzC[i] - xyzA[i];
+  }
+
+  std::vector<double> normalVec(3);
+
+
+  // recover vector normal to plane 
+  normalVec[0] = line1[1]*line2[2] - line1[2]*line2[1];
+  normalVec[1] = -(line1[0]*line2[2] - line1[2]*line2[0]);
+  normalVec[2] = line1[0]*line2[1] - line1[1]*line2[0];
+
+  // recover constant D in plane equation
+  D = -(normalVec[0]*xyzA[0] + normalVec[1]*xyzA[1] + normalVec[2]*xyzA[2]);
+}
+
+std::vector<double> triSource::get_random_pt()
+{
+  std::random_device dev;
+  std::mt19937 rng(dev());
+  std::uniform_real_distribution<double> dist(0,1);
+  double randomA = dist(rng);
+  double randomB = dist(rng);
+
+  if ((randomA + randomB) > 1) 
+  {
+    randomA = 1 - randomA;
+    randomB = 1 - randomB;
+  }
+
+  std::vector<double> randomPt(3);
+
+  for(int i=0; i<3; i++)
+  {
+    randomPt[i] = xyzA[i] + randomA*(xyzB[i] - xyzA[i]) + randomB*(xyzC[i] - xyzA[i]);
+  }
+  return randomPt;
+}

--- a/src/aegis_lib/source.cpp
+++ b/src/aegis_lib/source.cpp
@@ -34,9 +34,9 @@
 // 
 
 
-pointSource::pointSource(double xyz[3])
+pointSource::pointSource(std::vector<double> xyz)
 {
-  for (int i=0; i<3; i++)
+  for (int i=0; i<xyz.size(); i++)
   {
     r[i] = xyz[i];
   }

--- a/src/aegis_lib/source.cpp
+++ b/src/aegis_lib/source.cpp
@@ -142,9 +142,10 @@ triSource::triSource(std::vector<double> xyz1, std::vector<double> xyz2, std::ve
 
   // recover constant D in plane equation
   D = -(normalVec[0]*xyzA[0] + normalVec[1]*xyzA[1] + normalVec[2]*xyzA[2]);
+  normal = normalVec;
 }
 
-std::vector<double> triSource::get_random_pt()
+std::vector<double> triSource::random_pt()
 {
   std::random_device dev;
   std::mt19937 rng(dev());
@@ -166,6 +167,9 @@ std::vector<double> triSource::get_random_pt()
   }
   return randomPt;
 }
+
+
+
 
 void triSource::dagmcInstance(moab::DagMC* DAG)
 {

--- a/src/aegis_lib/source.h
+++ b/src/aegis_lib/source.h
@@ -85,9 +85,10 @@ class triSource
   double D;
 
   public:
+  std::vector<double> normal;
   triSource(std::vector<double> xyz1, std::vector<double> xyz2, std::vector<double> xyz3);
   void dagmcInstance(moab::DagMC* DAG); 
-  std::vector<double> get_random_pt();
+  std::vector<double> random_pt();
 };
 
 #endif

--- a/src/aegis_lib/source.h
+++ b/src/aegis_lib/source.h
@@ -36,20 +36,12 @@
 
 
 
-class Particle{
-  public:
-  std::string nameType; // i.e neutron
-  double weight; 
-  double dir[3]; // direction
-  double pos[3]; // position
-  double energy;
-};
+
 
 class pointSource{
   public:
   double r[3];
   double dir[3];
-  Particle neutron;
 
   pointSource(std::vector<double> xyz);
   void set_dir(double newDir[3]);
@@ -62,7 +54,6 @@ class sphereSource{
   public:
   double sample[3]; //sampled position
   double origin[3]; // origin of sphere
-  Particle neutron;
   double r; // radius of sphere
 };
 
@@ -72,11 +63,24 @@ class boxSource{
   double pB[3];
   double dir[3];
   double pR[3];
-  Particle neutron;
   boxSource(double xyz3[3], double xyz4[3]);
   void get_pt();
   void get_dir();
 
+};
+
+class triSource
+{
+
+  private:
+  std::vector<double> xyzA;
+  std::vector<double> xyzB;
+  std::vector<double> xyzC;
+  double D;
+
+  public:
+  triSource(std::vector<double> xyz1, std::vector<double> xyz2, std::vector<double> xyz3);
+  std::vector<double> get_random_pt();
 };
 
 #endif

--- a/src/aegis_lib/source.h
+++ b/src/aegis_lib/source.h
@@ -5,6 +5,10 @@
 #include <iostream>
 #include <cctype>
 #include <random>
+#include "DagMC.hpp"
+#include "moab/Core.hpp"
+#include "moab/Interface.hpp"
+#include <moab/OrientedBoxTreeTool.hpp>
 
 //create_source()
 
@@ -35,7 +39,9 @@
 // 
 
 
-
+using moab::DagMC;
+using moab::OrientedBoxTreeTool;
+moab::DagMC* DAGInstance;
 
 
 class pointSource{
@@ -80,6 +86,7 @@ class triSource
 
   public:
   triSource(std::vector<double> xyz1, std::vector<double> xyz2, std::vector<double> xyz3);
+  void dagmcInstance(moab::DagMC* DAG); 
   std::vector<double> get_random_pt();
 };
 

--- a/src/aegis_lib/source.h
+++ b/src/aegis_lib/source.h
@@ -51,7 +51,7 @@ class pointSource{
   double dir[3];
   Particle neutron;
 
-  pointSource(double xyz[3]);
+  pointSource(std::vector<double> xyz);
   void set_dir(double newDir[3]);
   void get_isotropic_dir();
   void get_hemisphere_surface_dir(double surfaceNormal[3]);

--- a/test/unit/aegis_unit.cpp
+++ b/test/unit/aegis_unit.cpp
@@ -364,7 +364,8 @@ TEST_F(aegisUnitTest, count_ray_facet_hits){
   DAG->moab_instance()->get_entities_by_type(0, MBTRI, Facets);
   surfaceIntegrator integrator(Facets);
   double pDir[3] = {0, 0, 1};
-  double pSource[3] = {0, 25, -5};
+  std::vector<double> pSource(3);
+  pSource = {0, 25, -5};
   pointSource spatialSource(pSource);
   spatialSource.set_dir(pDir);
   int nsample = 100;

--- a/test/unit/aegis_unit.cpp
+++ b/test/unit/aegis_unit.cpp
@@ -428,7 +428,7 @@ TEST_F(aegisUnitTest, polar_flux_coord_transform){
   equData EquData;
   EquData.read_eqdsk("test.eqdsk");
   EquData.init_interp_splines();
-  EquData.centre();
+  EquData.centre(1);
 
   std::vector<double> input = {2.4, 5.3, -2.0};
   std::vector<double> output;


### PR DESCRIPTION
- Added the capability to perform basic particle traces from the surface of a target geometry
- "Particles" are launched from a random point in each facet and tracked along fieldlines (tracking direction depends on the sign of B.n) and DagMC::ray_fire() is called at each step along the path to test for intersection with geometry
- A particle will terminate in the following conditions
   - Particle intersects with another part of the geometry
   - Particle leaves the magnetic domain (essentially the same as a particle hitting a graveyard)
   - Particle reaches the midplane. This needs to be changed to specifically be the outermidplane instead of just the midplane however
- Currently this is performed in a large nested loop in main. Will need to move away from this and towards more object oriented approach
- Also currently lacks any tests associated with the particle tracking