### PR TITLE
added calc of r_m and b_pm for power dep formula

### DIFF
--- a/src/aegis/aegis.cpp
+++ b/src/aegis/aegis.cpp
@@ -353,6 +353,7 @@ int main() {
     EquData.init_interp_splines();
     EquData.gnuplot_out();
     EquData.centre(1);
+    EquData.boundary_rb();
 
     // attempting to create a trace through magnetic field 
     // Currently not working

--- a/src/aegis/aegis.cpp
+++ b/src/aegis/aegis.cpp
@@ -29,7 +29,7 @@
 #include "integrator.h"
 #include "coordtfm.h"
 #include "alglib/interpolation.h"
-#include "particleTrack.h"
+
 
 using namespace moab;
 using namespace coordTfm;

--- a/src/aegis_lib/equData.h
+++ b/src/aegis_lib/equData.h
@@ -48,6 +48,7 @@ struct eqdskData
 class equData{
 
   eqdskData eqdsk;  
+  std::string className = "equData";
   
   // File streams
   std::ifstream eqdsk_file;
@@ -110,7 +111,12 @@ class equData{
 
   double dr; // step size in R (rmax-rmin)/nr
   double dz; // step size in Z (zmax-zmin)/nz
-  double dtheta = (thetamax-thetamin)/ntheta; // step size in theta (thetamax-thetamin)ntheta
+  double dtheta = (thetamax-thetamin)/ntheta;
+  
+  // Quantities needed for power depoisiton calculation
+  double rbdry; // R_m (R value at midplane)
+  double bpbdry; // B_pm (poloidal component of B at midplane)
+  double btotbdry; // B_m total B at reference boundary (midplane?) 
 
   // alglib grids
   alglib::real_1d_array r_grid; // 1D grid R[nw] with spacing = dr (KNOTS)
@@ -163,6 +169,7 @@ class equData{
 
   std::vector<double> b_ripple(std::vector<double> pos, std::vector<double> bField);
 
+  void boundary_rb();
 };
 
 #endif


### PR DESCRIPTION
- Added calculation of $R$ at outer midplane and poloidal component of $B$ at outer midplane. $R_m$ and $B_{pm}$
- These are to be used in a Eich formula like equation to calculate power deposited on each facet. Single exponential power deposition equation shown below:

$\huge q_{PFC}(\psi) = \frac{P_{SOL}}{4 \pi R_m \lambda_q B_{pm}} \boldsymbol{B} \cdot \boldsymbol{n} \exp{\left(-\frac{\psi - \psi_m}{R_m B_{pm} \lambda_q}\right)}$

Equation defined in https://www.sciencedirect.com/science/article/pii/S092037961930359X