### PR TITLE
Fixed ray launch directions and added power deposition per triangle

### DIFF
--- a/settings.txt
+++ b/settings.txt
@@ -1,4 +1,4 @@
-geo_input hcll_up.h5m
+geo_input hcll.h5m
 ray_qry exps/exps00010000.qry
 runcase eqdsk
 eqdsk_file eqdsk/test.eqdsk 

--- a/src/aegis_lib/equData.cpp
+++ b/src/aegis_lib/equData.cpp
@@ -1087,13 +1087,19 @@ void equData::boundary_rb()
 
 
   zpsi = psiqbdry;
+  LOG_WARNING << "psiqbdry from EQDSK = " << zpsi;
   re = rcen + zsr*zcostheta;
   ze = zcen + zsr*zsintheta;
   alglib::spline2ddiff(psiSpline, re, ze, zpsi, zdpdr, zdpdz, zddpdz);
+  psibdry = zpsi;
+
+  LOG_WARNING << "psibdry calculated from splines = " << zpsi;
+
 
   // store R_m and B_pm
 
   rbdry = re;
+  zbdry = ze;
   bpbdry = (1/re)*sqrt(std::max(0.0, (pow(zdpdr,2) + pow(zdpdz, 2))));
 
   double zbr; // radial Bfield component
@@ -1124,7 +1130,20 @@ void equData::boundary_rb()
   LOG_WARNING << "Toroidal BField component " << zbt;
 }
 
+double equData::omp_power_dep(double psi, double Psol, double lambda_q, double bn)
+{
+  double heatFlux;
+  double exponential, pConstant;
+  double zpsim = psibdry;
+  double zbpm = bpbdry;
+  double zrm = rbdry;
 
+  pConstant = Psol/(4*M_PI*zrm*lambda_q*zbpm);
+  exponential = exp(-(psi-zpsim)/(zrm*zbpm*lambda_q));
+
+  heatFlux = fabs((pConstant*bn)*exponential);
+  return heatFlux;
+}
 
 // void equData::set_omp()
 // {

--- a/src/aegis_lib/equData.h
+++ b/src/aegis_lib/equData.h
@@ -114,9 +114,11 @@ class equData{
   double dtheta = (thetamax-thetamin)/ntheta;
   
   // Quantities needed for power depoisiton calculation
-  double rbdry; // R_m (R value at midplane)
+  double rbdry; // R_m (R value at omp)
+  double zbdry; // Z_m (Z value at omp)
   double bpbdry; // B_pm (poloidal component of B at midplane)
   double btotbdry; // B_m total B at reference boundary (midplane?) 
+  double psibdry; // psi at omp calculated from splines nad golden search
 
   // alglib grids
   alglib::real_1d_array r_grid; // 1D grid R[nw] with spacing = dr (KNOTS)
@@ -169,7 +171,10 @@ class equData{
 
   std::vector<double> b_ripple(std::vector<double> pos, std::vector<double> bField);
 
+  // Determine Rm and Bpm (R and Bpol at omp)
   void boundary_rb();
+
+  double omp_power_dep(double psi, double Psol, double lambda_q, double bn);
 };
 
 #endif

--- a/src/aegis_lib/integrator.cpp
+++ b/src/aegis_lib/integrator.cpp
@@ -30,6 +30,17 @@ void surfaceIntegrator::count_hit(EntityHandle facet_hit)
   raysHit +=1;
 }
 
+void surfaceIntegrator::count_lost_ray()
+{
+  raysLost += 1;
+}
+
+void surfaceIntegrator::store_heat_flux(EntityHandle facet, double heatflux)
+{
+  powFac[facet] += heatflux; // tally accumulated heatflux on facet
+  raysHeatDep += 1; 
+}
+
 
 void surfaceIntegrator::ray_reflect_dir(double const prev_dir[3], double const surface_normal[3], 
                                         double reflected_dir[3])
@@ -60,12 +71,16 @@ void surfaceIntegrator::facet_values(std::unordered_map<moab::EntityHandle, int>
 // return sorted map of EntityHandles against doubles 
 void surfaceIntegrator::facet_values(std::unordered_map<moab::EntityHandle, double> const &map)
 {
+    std::cout << std::endl;
+    std::cout << "Heat flux deposited per facet" << std::endl;
+    std::cout << std::endl;
+
     dbl_sorted_map sortedMap(map.begin(), map.end());
     for (auto const &pair: sortedMap)
     {
       if (pair.second > 0)
       {
-        std::cout << "EntityHandle: " << pair.first << "[" << pair.second << "] rays hit" << std::endl;
+        std::cout << "EntityHandle:" << pair.first << " [" << pair.second << "] W/m^2" << std::endl;
       }
     }
 }

--- a/src/aegis_lib/integrator.h
+++ b/src/aegis_lib/integrator.h
@@ -43,9 +43,10 @@ class surfaceIntegrator
   public:
 
   int raysTotal=0; // Total number of rays fired into geometry
-  int raysHit=0; // Number of rays hit
+  int raysHit=0; // Number of rays hit shadowing
+  int raysLost=0;
+  int raysHeatDep=0;
   int nFacets=0; // Number of facets in geometry
-  int raysLost;
   std::vector<EntityHandle> facetEntities; // list of all entity handles in geometry
   std::unordered_map<EntityHandle, int> nRays; // Number of rays intersected with a given surface EntityHandle
   std::unordered_map<EntityHandle, double> powFac; // power assigned to each facet
@@ -53,13 +54,14 @@ class surfaceIntegrator
   // Methods
   surfaceIntegrator(moab::Range const &Facets); // constructor
   void count_hit(EntityHandle facet_hit); // count hits belonging to each facet
-  void store_heat_flux(EntityHandle facet, double psi, equData EquData); // store the power associated with a particular facet
+  void count_lost_ray();
+  void store_heat_flux(EntityHandle facet, double heatflux); // store the power associated with a particular facet
 
   void ray_reflect_dir(double const prev_dir[3], double const surface_normal[3], // get reflected dir
                          double reflected_dir[3]); 
   
   // return sorted map of entityhandles against chosen value
-  void facet_values(std::unordered_map<EntityHandle, int> const &facetValueMap);
+  void facet_values(std::unordered_map<EntityHandle, int> const &map);
   void facet_values(std::unordered_map<EntityHandle, double> const &map);
 
 /// TODO - Create a class that holds the unordered map and a string for the name of the map

--- a/src/aegis_lib/source.cpp
+++ b/src/aegis_lib/source.cpp
@@ -137,7 +137,7 @@ triSource::triSource(std::vector<double> xyz1, std::vector<double> xyz2, std::ve
 
   // recover vector normal to plane 
   normalVec[0] = line1[1]*line2[2] - line1[2]*line2[1];
-  normalVec[1] = -(line1[0]*line2[2] - line1[2]*line2[0]);
+  normalVec[1] = line1[2]*line2[0] - line1[0]*line2[2];
   normalVec[2] = line1[0]*line2[1] - line1[1]*line2[0];
 
   // recover constant D in plane equation


### PR DESCRIPTION
Lots of changes/additions in order to capability for power deposition per triangle to AEGIS. 

**Note** - The current power deposition implementation in `aegis.cpp` has hard coded values for $P_{SOL}$ and $\lambda_q$ as I don't currently know what these values should be in a run

**Changes:**
- Triangle vertices are now stored within a `std::vector`. Previously vertices returned from `moab_instance()` were stored within a `moab::Range` container which are not contiguous whereas `std::vectors` are. Some normals would be backwards as the order in which their vertices were defined was inconsistent leading to cross-product returning inconsistent normals
- Skip first instance of `DagMC::ray_fire()` when launching from the surface of a triangle. Seemed to have issues with rays intersecting the surface they are launched from. This change has fixed that particular issue
- Changed sign of 2nd cross-product component in `triSource::triSource()` 
- Geometry in `settings.txt` set to HCLL at x-point in eqdsk 
- Hard code global id of surface of interest (front facing panel on HCLL) to return all facets in surface `targetSurf = DAG->entity_by_id(2, 479); // front facing surface of HCLL`

**Additions:**
- New method `double equData::omp_power_dep`($\psi$, $P_{SOL}$, $\lambda_q$, $\boldsymbol{B} \cdot \boldsymbol{n}$) used to calculate the power heat flux density incident on a PFC triangle from the equation $q_{PFC}(\psi) = \frac{P_{SOL}}{4 \pi R_m \lambda_q B_{pm}} \boldsymbol{B} \cdot \boldsymbol{n} \exp{\left(-\frac{\psi - \psi_m}{R_m B_{pm} \lambda_q}\right)}$ 
- New method `void surfaceIntegrator::count_lost_ray()` adds a score to the tally for rays lost (typically used when rays leave magnetic domain defined by eqdsk)
- New method `surfaceIntegrator::store_heat_flux(moab::EntityHandle facet, double heatFlux)` to score heatFlux from `omp_power_dep()` onto tally for a particular facet given by its EntityHandle 
- Added method overload `void surfaceIntegrator::facet_values(std::unordered_map<moab::EntityHandle, double> const &map)` to allow for sorting and printing of type `double` within `unordered_map`

**Actions:**
- Remove hard coded $P_{SOL}$ and $\lambda_q$ parameters and replace with actual representative values for $SOL$
- Write some tests for the new particle tracking and tallying features 
- Create a format for output of heat flux densities ready to be read into MOOSE  
- Find a way to get multiple surfaces of interest instead of just single surface 
- Find a way to specify this surface of interest without reliance on hard coding the global id in `DAG->entity_by_id(2,id)`