### PR TITLE
particle tracking multiblock and surface heatmap output setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_minimum_required(VERSION 3.8)
 set(PROJECT_NAME aegis) 
 set(PROJECT_LIB_NAME ${PROJECT_NAME}-lib)
 
+message(STATUS "CMAKE Compiler is:" ${CMAKE_CXX_COMPILER})
+
 project(${PROJECT_NAME} VERSION 0.0.0 LANGUAGES CXX)
 set (CMAKE_CXX_STANDARD 17)
 #set (CMAKE_CXX_CLANG_TIDY 
@@ -24,7 +26,33 @@ find_package(OpenMP REQUIRED)
 #include(${CMAKE_SOURCE_DIR}/cmake/SetBuildType.cmake)
 
 # Set debugging symbols
-set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_BUILD_TYPE DEBUG)
+
+# Import VTK
+find_package(VTK COMPONENTS REQUIRED
+   CommonCore
+   CommonDataModel
+   FiltersCore
+   FiltersGeometry
+   FiltersSources
+   IOXML
+   IOGeometry
+   IOLegacy
+)
+
+message (STATUS "Found VTK COMPONENTS" ${VTK_DIR})
+
+if (NOT VTK_FOUND)
+  message(FATAL_ERROR "Unable to find the VTK build folder.")
+endif()
+
+#target_link_libraries(${PROJECT_NAME} PRIVATE ${VTK_LIBRARIES})
+
+# vtk_module_autoinit is needed
+vtk_module_autoinit(
+  TARGETS ${PROJECT_NAME}
+  MODULES ${VTK_LIBRARIES}
+)
 
 
 # Import DAGMC
@@ -63,13 +91,15 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
 if(BUILD_TYPE STREQUAL "TEST")
   set(BUILD_TYPE_COMPILE_FLAGS "-g;-O0;--coverage")
   set(TEST_LIBRARIES "gcov")
-elseif(BUILD_TYPE STREQUAL "DEBUG")
-  set(BUILD_TYPE_COMPILE_FLAGS "-g -O0")
+elseif(CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+  set(BUILD_TYPE_COMPILE_FLAGS "-g;-O0")
   set(TEST_LIBRARIES "")
 elseif(BUILD_TYPE STREQUAL "RELEASE")
   set(BUILD_TYPE_COMPILE_FLAGS "-O2")
   set(TEST_LIBRARIES "")
 endif()
+
+message(STATUS "BUILD_TYPE_COMPILE_FLAGS" ${BUILD_TYPE_COMPILE_FLAGS})
 
 ############################################################
 # Add directories with source files

--- a/settings.txt
+++ b/settings.txt
@@ -1,6 +1,11 @@
-geo_input hcll.h5m
+DAGMC_input mast.h5m
+VTK_input mast.stl
 ray_qry exps/exps00010000.qry
 runcase eqdsk
-eqdsk_file eqdsk/test.eqdsk 
-source_power 100.0
+trace yes
+eqdsk_file eqdsk/equil_MAST.eqdsk 
+Psol 3.2
+lambda_q 6.187
 cenopt 2
+surf 479
+number_of_rays_launched_per_tri 5

--- a/src/aegis_lib/CMakeLists.txt
+++ b/src/aegis_lib/CMakeLists.txt
@@ -9,11 +9,18 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 # make a shared object library to link against for testing
 add_library(${PROJECT_LIB_NAME} SHARED ${lib_files})
-target_compile_options(${PROJECT_LIB_NAME} PRIVATE ${BUILD_TYPE_COMPILE_FLAGS})
+target_compile_options(${PROJECT_LIB_NAME} PUBLIC ${BUILD_TYPE_COMPILE_FLAGS})
 set_target_properties(${PROJECT_LIB_NAME} PROPERTIES LINKER_LANGUAGE CXX)
 set_target_properties(${PROJECT_LIB_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 target_include_directories(${PROJECT_LIB_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${Boost_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_LIB_NAME} PUBLIC ${Boost_LIBRARIES} ${TEST_LIBRARIES})
 target_link_libraries(${PROJECT_LIB_NAME} PUBLIC dagmc-shared uwuw-shared )
 target_link_libraries(${PROJECT_LIB_NAME} PUBLIC OpenMP::OpenMP_CXX)
+target_link_libraries(${PROJECT_LIB_NAME} PUBLIC ${VTK_LIBRARIES})
+
+# vtk_module_autoinit is needed
+#vtk_module_autoinit(
+#  TARGETS ${PROJECT_NAME_LIB}
+#  MODULES ${VTK_LIBRARIES}
+#)
 

--- a/src/aegis_lib/equData.cpp
+++ b/src/aegis_lib/equData.cpp
@@ -822,6 +822,10 @@ void equData::write_bfield(bool plotRZ, bool plotXYZ)
     std::vector<double> cartB(3); // cartesian magnetic field B(Bx, By, Bz)
     int phiSamples = 12;
     double dphi = 2*M_PI/phiSamples;
+    
+    BField_out_xyz << "x" << " " << "y" << " " << "z" << " " 
+		   << "Bx" << " " << "By" << " " << "Bz" << " " 
+		   << "r" << " " << "z" << " " << "phi" << std::endl;
 
     for (int k=0; k<=phiSamples; k++) // loop through phi
     {
@@ -1125,9 +1129,9 @@ void equData::boundary_rb()
   zbz = (1/re)*zdpdr;
   zbt = zf/re;
 
-  LOG_WARNING << "Radial BField component " << zbr;
-  LOG_WARNING << "Vertical BField component " << zbz;
-  LOG_WARNING << "Toroidal BField component " << zbt;
+  LOG_WARNING << "Radial BField component (Br) " << zbr;
+  LOG_WARNING << "Vertical BField component (Bz) " << zbz;
+  LOG_WARNING << "Toroidal BField component (Bt) " << zbt;
 }
 
 double equData::omp_power_dep(double psi, double Psol, double lambda_q, double bn)

--- a/src/aegis_lib/integrator.h
+++ b/src/aegis_lib/integrator.h
@@ -2,6 +2,7 @@
 #define integrator__
 
 #include <iostream>
+#include <stdio.h>
 #include <cctype>
 #include <vector>
 #include <map>
@@ -50,7 +51,8 @@ class surfaceIntegrator
   std::vector<EntityHandle> facetEntities; // list of all entity handles in geometry
   std::unordered_map<EntityHandle, int> nRays; // Number of rays intersected with a given surface EntityHandle
   std::unordered_map<EntityHandle, double> powFac; // power assigned to each facet
-  
+  std::unordered_map<EntityHandle, std::vector<double>> launchPositions; // launch positions on each facet
+
   // Methods
   surfaceIntegrator(moab::Range const &Facets); // constructor
   void count_hit(EntityHandle facet_hit); // count hits belonging to each facet
@@ -63,6 +65,10 @@ class surfaceIntegrator
   // return sorted map of entityhandles against chosen value
   void facet_values(std::unordered_map<EntityHandle, int> const &map);
   void facet_values(std::unordered_map<EntityHandle, double> const &map);
+
+  void csv_out(std::unordered_map<moab::EntityHandle, double> const &map);
+  void piecewise_multilinear_out(std::unordered_map<moab::EntityHandle, double> const &map);
+
 
 /// TODO - Create a class that holds the unordered map and a string for the name of the map
 ///      - Potentially also any other variables that may be useful (i.e units for power values) 

--- a/src/aegis_lib/settings.cpp
+++ b/src/aegis_lib/settings.cpp
@@ -29,9 +29,13 @@
         in >> param;
         in >> valueStr;
 
-        if (param == "geo_input")
+        if (param == "DAGMC_input")
         {
-          geo_input = valueStr; // string
+          dagmc_input = valueStr; // string
+        }
+        if (param == "VTK_input")
+        {
+          vtk_input = valueStr;
         }
         else if (param == "ray_qry")
         {
@@ -45,20 +49,34 @@
         {
           runcase = valueStr; // string
         }
-	      else if (param == "source_power")
+        else if (param == "trace")
+        {
+          trace = valueStr;
+        }
+	      else if (param == "Psol")
 	      {
-	      source_power = valueStr; // double
+	        Psol = std::stod(valueStr); // double
 	      }
+        else if (param == "lambda_q")
+        {
+          lambda_q = std::stod(valueStr);
+        }
 	      else if (param == "reflections")
 	      {
 	      reflections = valueStr; // int
 	      }
-        else if (param == "number_of_rays_fired")
+        else if (param == "number_of_rays_launched_per_tri")
 	      {
-	      nSample = valueStr; // int
+	        nSample = std::stoi(valueStr); // int
 	      }
         else if (param == "cenopt")
-        cenopt = std::stoi(valueStr);
+        {
+          cenopt = std::stoi(valueStr);
+        }
+        else if (param == "surf")
+        {
+          surf = std::stoi(valueStr);
+        }
       }
       in.close();
     }

--- a/src/aegis_lib/settings.hpp
+++ b/src/aegis_lib/settings.hpp
@@ -6,13 +6,17 @@
 class settings{
   public: 
     std::string ray_qry;
-    std::string geo_input;
+    std::string dagmc_input;
+    std::string vtk_input;
     std::string runcase;
     std::string eqdsk_file;
-    std::string source_power;
+    std::string trace;
+    double Psol;
+    double lambda_q;
     std::string reflections;
-    std::string nSample;
+    int nSample;
     int cenopt;
+    int surf;
     void load_settings();
 };
 


### PR DESCRIPTION
Lots of things here, mostly additions in the form of direct vtk integration within Aegis to create outputs ready to visualised in ParaView. 

**Changes:** 
- `equData::write_bfield()` now outputs to a txt file (space seperated) that contains Headers. ParaView automatically reads those headers so makes it a bit easier to work with
- Changed the way in which `surfaceIntegrator::store_heat_flux()` interacts with particle tracks that accumulate 0.0 heatflux. Previously `surfaceIntegrator::store_heat_flux()` would not be called on these facets leading to facets with undefined heatflux. Now the method is called and a running counter of particle tracks that deposit `heatflux > 0.0` is also stored 
- Added some new options to `settings.cpp`: 
   - `geo_input` replaced by `DAGMC_input` - `.h5m` filename
   - `VTK_input` - New input expecting `.stl` file which is used to create the vtkUnstructuredGrid that holds heatflux values per cell
   - `trace` - Option to write out particle trace files as vtkMultiBlock `particle_trace.vtm` 
   - `Psol` - Total power at scrape off layer to be mapped onto first wall components (parameter in `equData::omp_power_dep`) 
   - `lambda_q` - Scrape off layer width (parameter in `equData::omp_power_dep`)
   - `surf` - select the global ids of the surface of interest (to be used as target that launches particles)
- By default particles are launched from all facets, unless particular surfaces are specified


**Additions:**
- New method `void surfaceIntegrator::csv_out(map<EntityHandle, double>)` that is used to write out heatflux point data to csv format (`X-Coord, Y-Coord, Z-Coord, heatflux)` 
- Added a `clock` object to `Aegis.cpp` that provides an elapsed time for each run
- Added the necessary commands to the CMakeLists to import the VTK library. Individual components currently imported are: `CommonCore, CommonDataModel, FiltersCore, FiltersGeometry, FiltersSources, IOXML, IOGeometry, IOLegacy` 
- Added `#include` statements for various vtk header files
- Added the capability to read in an `.stl` file which is converted to a `vtkUnstructuredGrid` within the code and has an array appended to store `heatflux` values per triangle 
- Definition of `vtkMultiBlock` structure (written out to `.vtm`) that holds `vtkPolyData` lines for individual particle tracks. The multiblock is a hierarchical data structure that has a tree like structure of blocks. In Aegis the multiblock consists of three blocks  that make up the particle tracks:
   - `Shadowed Particles` - These are tracks that hit a piece of CAD geometry before reaching the outer-midplane or leaving the magnetic domain 
   - `Lost Particles` - Particles that leave the magnetic domain before hitting a piece of CAD geometry or reaching the outer-midplane
   - `Depositing Particles` - Particles that reach the outer-midplane and therefore deposit power on a facet 
- Individual particle tracks (`vtkPolyData`) also have an array to store heatflux they are associated with in order to colour by in ParaView 
- Added ability to write out `vtkMultiBlock` to `.vtm XML` file ready to be visualised in ParaView 
- Added ability to write out `vtkUnstructuredGrid` with array holding heatflux values to colour cells by in ParaView. Currently not working with particular geometry/eqdsk combinations


**Actions**
- Add max number of samples per particle track `nS` and particle track stepsize `ds` to `settings.cpp`
- Cleanup the new VTK code for the particle track multiblock structure
- Need to do a pretty big code restructure. Aegis `main` has way too much going on in large nested structures. Want to partition code better into individual classes/functions
- Make `vtkUnstructuredGrid` write out more robust than it currently is. Works fine with Mast eqdsk with rescaled HCLL geometry but does NOT work with EQ3.eqdsk with HCLL geometry
- Want to add the ability to launch from the surface of geometry in a more uniform-like grid